### PR TITLE
处理Rafy ORM Sql Server 中 DateTime 类型的字段溢出的问题 #101

### DIFF
--- a/Rafy/Rafy/DbMigration/Providers/DbTypeHelper.cs
+++ b/Rafy/Rafy/DbMigration/Providers/DbTypeHelper.cs
@@ -35,6 +35,7 @@ namespace Rafy.DbMigration
             if (clrType == typeof(long)) { return DbType.Int64; }
             if (clrType == typeof(bool)) { return DbType.Boolean; }
             if (clrType == typeof(DateTime)) { return DbType.DateTime; }
+            if (clrType == typeof(DateTimeOffset)) { return DbType.DateTimeOffset; }
             if (clrType == typeof(Guid)) { return DbType.Guid; }
             if (clrType == typeof(double)) { return DbType.Double; }
             if (clrType == typeof(byte)) { return DbType.Byte; }
@@ -70,6 +71,8 @@ namespace Rafy.DbMigration
                 case DbType.AnsiStringFixedLength:
                     return string.Empty;
                 case DbType.DateTime:
+                case DbType.DateTime2:
+                case DbType.DateTimeOffset:
                     return new DateTime(2000, 1, 1, 0, 0, 0);
                 case DbType.Guid:
                     return Guid.Empty.ToString();

--- a/Rafy/Rafy/DbMigration/Providers/MySql/MySqlDbTypeHelper.cs
+++ b/Rafy/Rafy/DbMigration/Providers/MySql/MySqlDbTypeHelper.cs
@@ -65,6 +65,7 @@ namespace Rafy.DbMigration.MySql
 
         /// <summary>
         /// 把 DbType的类型值 转换为 MySql 数据库中兼容的数据类型
+        /// MySql数据精度 http://qimo601.iteye.com/blog/1622368
         /// </summary>
         /// <param name="fieldType">字段的DbType类型值</param>
         /// <param name="length">数据类型的长度</param>
@@ -95,12 +96,11 @@ namespace Rafy.DbMigration.MySql
                 case DbType.UInt64:
                 case DbType.Int64:
                     return "BIGINT";
-                case DbType.DateTimeOffset:
-                    return "TIMESTAMP";
                 case DbType.Time:
                     return "TIME";
                 case DbType.Date:
                     return "DATE";
+                case DbType.DateTimeOffset:
                 case DbType.DateTime:
                     return "DATETIME";
                 case DbType.Single:
@@ -219,7 +219,7 @@ namespace Rafy.DbMigration.MySql
                 }
                 else if (string.Compare(mySqlType, "TIMESTAMP", true) == 0)
                 {
-                    return DbType.DateTimeOffset;
+                    return DbType.DateTime;
                 }
                 else
                 {

--- a/Rafy/Rafy/DbMigration/Providers/Oracle/OracleDbTypeHelper.cs
+++ b/Rafy/Rafy/DbMigration/Providers/Oracle/OracleDbTypeHelper.cs
@@ -71,6 +71,8 @@ namespace Rafy.DbMigration.Oracle
                 case DbType.Int32:
                     return "INTEGER";
                 case DbType.DateTime:
+                case DbType.DateTime2:
+                case DbType.DateTimeOffset:
                     return "DATE";
                 case DbType.Byte:
                 case DbType.Single:

--- a/Rafy/Rafy/DbMigration/Providers/SqlServer/SqlDbTypeHelper.cs
+++ b/Rafy/Rafy/DbMigration/Providers/SqlServer/SqlDbTypeHelper.cs
@@ -42,6 +42,10 @@ namespace Rafy.DbMigration.SqlServer
                     return "BIGINT";
                 case DbType.DateTime:
                     return "DATETIME";
+                case DbType.DateTime2:
+                    return "DATETIME2";
+                case DbType.DateTimeOffset:
+                    return "DATETIMEOFFSET";
                 case DbType.Guid:
                     return "UNIQUEIDENTIFIER";
                 case DbType.Double:
@@ -110,9 +114,12 @@ namespace Rafy.DbMigration.SqlServer
                     return DbType.Byte;
                 case "date":
                 case "datetime":
-                case "datetimeoffset":
                 case "time":
                     return DbType.DateTime;
+                case "datetime2":
+                    return DbType.DateTime2;
+                case "datetimeoffset":
+                    return DbType.DateTimeOffset;
                 default:
                     throw new NotSupportedException(string.Format("不支持读取数据库中的列类型：{0}。", sqlType));
             }

--- a/Rafy/Rafy/Domain/LiteDataTableExtension.cs
+++ b/Rafy/Rafy/Domain/LiteDataTableExtension.cs
@@ -69,16 +69,13 @@ namespace Rafy.Domain
                         var columnMeta = propertyMeta.ColumnMeta;
                         var columnName = columnMeta == null ? propertyMeta.Name : columnMeta.ColumnName ?? propertyMeta.Name;
 
-                        for (int j = 0, c2 = tableColumnsNameList.Count; j < c2; j++)
+                        if (tableColumnsNameList.Contains(columnName, StringComparer.OrdinalIgnoreCase))
                         {
-                            if (tableColumnsNameList.Contains(columnName))
+                            propertyToColumnMappings.Add(new PropertyToColumnMapping
                             {
-                                propertyToColumnMappings.Add(new PropertyToColumnMapping
-                                {
-                                    Property = manageProperty,
-                                    ColumnName = columnName
-                                });
-                            }
+                                Property = manageProperty,
+                                ColumnName = columnName
+                            });
                         }
                     }
                 }
@@ -101,7 +98,7 @@ namespace Rafy.Domain
                 }
             }
 
-            return ConvertEntitiesIntoList(liteDataTable, repo, propertyToColumnMappings) as TEntityList;
+            return ConvertEntitiesIntoList(liteDataTable, repo, propertyToColumnMappings, columnMapToProperty) as TEntityList;
         }
 
         /// <summary>

--- a/Rafy/Rafy/Domain/ORM/Rdb/Sql/MySql/MySqlSqlGenerator.cs
+++ b/Rafy/Rafy/Domain/ORM/Rdb/Sql/MySql/MySqlSqlGenerator.cs
@@ -133,6 +133,10 @@ namespace Rafy.Domain.ORM.MySql
                 {
                     value = TypeHelper.CoerceValue(typeof(int), value);
                 }
+                if (value is DateTimeOffset)
+                {
+                    value = TypeHelper.CoerceValue(typeof(DateTime), value);
+                }
             }
 
             return value;

--- a/Rafy/Rafy/Domain/ORM/Rdb/Sql/MySql/MySqlTable.cs
+++ b/Rafy/Rafy/Domain/ORM/Rdb/Sql/MySql/MySqlTable.cs
@@ -39,6 +39,16 @@ namespace Rafy.Domain.ORM.MySql
         public MySqlTable(IRepositoryInternal repository) : base(repository) { }
 
         /// <summary>
+        /// 构造函数 初始化表和 持久列信息
+        /// </summary>
+        /// <param name="columnInfo"></param>
+        /// <returns></returns>
+        internal override RdbColumn CreateColumn(IPersistanceColumnInfo columnInfo)
+        {
+            return new MySqlColumn(this, columnInfo);
+        }
+
+        /// <summary>
         /// 创建Sql生成器对象
         /// </summary>
         /// <returns></returns>

--- a/Rafy/Rafy/Domain/ORM/Rdb/Sql/Oracle/OracleSqlGenerator.cs
+++ b/Rafy/Rafy/Domain/ORM/Rdb/Sql/Oracle/OracleSqlGenerator.cs
@@ -84,6 +84,10 @@ namespace Rafy.Domain.ORM.Oracle
                 {
                     value = TypeHelper.CoerceValue(typeof(int), value);
                 }
+                else if (value is DateTimeOffset)
+                {
+                    value = TypeHelper.CoerceValue(typeof(DateTime), value);
+                }
             }
 
             return value;

--- a/Rafy/Rafy/Utils/Reflection/TypeHelper.cs
+++ b/Rafy/Rafy/Utils/Reflection/TypeHelper.cs
@@ -270,6 +270,20 @@ namespace Rafy.Reflection
             //处理 Guid
             if (desiredType == typeof(Guid) && value is string) { return Guid.Parse(value as string); }
 
+            //处理 DateTimeOffset
+            // DateTime to DateTimeOffset  https://msdn.microsoft.com/zh-cn/library/bb546101.aspx
+            // DateTime DateTime2 区别 http://www.studyofnet.com/news/1050.html
+            if (desiredType == typeof(DateTimeOffset) && value is DateTime)
+            {
+                return (DateTimeOffset)DateTime.SpecifyKind((DateTime)value, DateTimeKind.Local);
+            }
+
+            //DateTime to DateTimeOffset
+            if (desiredType == typeof(DateTime) && value is DateTimeOffset)
+            {
+                return ((DateTimeOffset)value).DateTime;
+            }
+
             try
             {
                 return Convert.ChangeType(value, desiredType);

--- a/Test/Rafy.UnitTest/Entities/Yacht.cs
+++ b/Test/Rafy.UnitTest/Entities/Yacht.cs
@@ -110,6 +110,17 @@ namespace Rafy.UnitTest
         }
 
 
+        public static readonly Property<DateTimeOffset> DateTimeOffsetValueProperty = P<Yacht>.Register(e => e.DateTimeOffsetValue);
+        /// <summary>
+        /// 日期
+        /// <para>注意：SqlCe不支持该类型</para>  
+        /// </summary>
+        public DateTimeOffset DateTimeOffsetValue
+        {
+            get { return this.GetProperty(DateTimeOffsetValueProperty); }
+            set { this.SetProperty(DateTimeOffsetValueProperty, value); }
+        }
+
         #endregion
 
         #region 只读属性

--- a/Test/RafyUnitTest/Rafy/EntityTest.cs
+++ b/Test/RafyUnitTest/Rafy/EntityTest.cs
@@ -341,6 +341,30 @@ namespace RafyUnitTest
             }
         }
 
+        /// <summary>
+        /// 该测试不支持SqlCe，因为SqlCe只有DateTime类型并且精度不够
+        /// https://technet.microsoft.com/zh-cn/library/ms172424(v=sql.110).aspx
+        /// </summary>
+        [TestMethod]
+        public void ET_Property_DateTimeOffset()
+        {
+            using (RF.TransactionScope(UnitTestEntityRepositoryDataProvider.DbSettingName))
+            {
+                Yacht car = new Yacht()
+                {
+                    DateTimeOffsetValue = DateTime.Parse("1230-1-1")
+                };
+                var repo = RF.ResolveInstance<YachtRepository>();
+                repo.Save(car);
+
+                long id = car.Id;
+                var newCar = repo.GetById(id);
+
+                Assert.AreEqual(newCar.DateTimeOffsetValue, car.DateTimeOffsetValue);
+            }
+        }
+
+
         [TestMethod]
         public void ET_Property_Enum_ForUI()
         {


### PR DESCRIPTION
1、框架添加对DateTimeOffset类型的支持
2、修改MySqlDbTypeHelper中对于DateTimeOffset类型的映射
3、TypeHelper中添加对DtateTimeOffset和DateTime的转换
4、测试通过Oracle，MySql，SqlServer，其中Oralce和MySql的DateTime类型满足精度要求，添加响应的映射就可以了
5、由于SqlCe只有DateTime类型且精度  1753-1-1到 9999-12-31 所以SqlCe暂不做处理